### PR TITLE
feat: web worker instance as embed provider

### DIFF
--- a/packages/embed/src/types/index.ts
+++ b/packages/embed/src/types/index.ts
@@ -8,6 +8,11 @@ export enum MessageStatus {
 
 export type { ProgressInfo }
 
+export interface EmbedProviderOptions {
+  baseURL?: string
+  worker?: Worker
+}
+
 export interface Extract {
   options?: FeatureExtractionPipelineOptions
   text: string | string[]

--- a/packages/shared/src/worker/worker.ts
+++ b/packages/shared/src/worker/worker.ts
@@ -43,6 +43,7 @@ export const createTransformersWorker = <
       throw new Error('Payload is required')
 
     return new Promise<void>((resolve, reject) => {
+      /* eslint-disable sonarjs/cognitive-complexity */
       if (!createOptions.worker && !createOptions.workerURL)
         throw new Error('Either worker or workerURL is required')
 

--- a/packages/shared/src/worker/worker.ts
+++ b/packages/shared/src/worker/worker.ts
@@ -30,7 +30,6 @@ export interface WorkerOptions {
   workerURL?: string | undefined | URL
 }
 
-/* eslint-disable sonarjs/cognitive-complexity */
 export const createTransformersWorker = <
   T extends WorkerOptions,
   T2 extends { onProgress?: LoadOptionProgressCallback },
@@ -114,7 +113,6 @@ export const createTransformersWorker = <
       }
     })
   }
-  /* eslint-enable sonarjs/cognitive-complexity */
 
   const ensureLoadBeforeProcess = async (options?: T2 & { loadOptions?: { options?: T2, payload: LoadMessageEvents<any, string> } }) => {
     if (options != null && !options?.loadOptions)

--- a/tsconfig.lib.json
+++ b/tsconfig.lib.json
@@ -1,6 +1,7 @@
 {
   "extends": "@importantimport/tsconfig/app.json",
   "compilerOptions": {
+    "moduleResolution": "bundler",
     "types": [
       "vite/client",
       // @webgpu/types


### PR DESCRIPTION
Update `createEmbedProvider` to accept either baseURL or a web worker instance. This would make it compatible with the web-worker package for Node.js.