### PR TITLE
refactor: migrate to @xsai-ext/providers due to deprecation

### DIFF
--- a/packages-top/xsai-transformers/package.json
+++ b/packages-top/xsai-transformers/package.json
@@ -62,7 +62,7 @@
     }
   },
   "dependencies": {
-    "@xsai-ext/shared-providers": "catalog:",
+    "@xsai-ext/providers": "catalog:",
     "@xsai-transformers/chat": "workspace:^",
     "@xsai-transformers/embed": "workspace:^",
     "@xsai-transformers/shared": "workspace:^",

--- a/packages/chat/package.json
+++ b/packages/chat/package.json
@@ -56,7 +56,7 @@
     "@huggingface/transformers": "^3.7.6",
     "@moeru/eventa": "^0.3.0",
     "@moeru/std": "^0.1.0-beta.13",
-    "@xsai-ext/shared-providers": "catalog:",
+    "@xsai-ext/providers": "catalog:",
     "@xsai-transformers/shared": "workspace:^",
     "@xsai/generate-object": "catalog:",
     "@xsai/generate-text": "catalog:",

--- a/packages/chat/src/index.ts
+++ b/packages/chat/src/index.ts
@@ -1,4 +1,4 @@
-import type { ChatProviderWithExtraOptions } from '@xsai-ext/shared-providers'
+import type { ChatProviderWithExtraOptions } from '@xsai-ext/providers/utils'
 import type { LoadOptionProgressCallback, LoadOptions } from '@xsai-transformers/shared/types'
 import type { CommonRequestOptions } from '@xsai/shared'
 import type { ChatOptions } from '@xsai/shared-chat'

--- a/packages/chat/src/types/index.ts
+++ b/packages/chat/src/types/index.ts
@@ -1,5 +1,5 @@
 import type { pipeline } from '@huggingface/transformers'
-import type { CreateProviderOptions } from '@xsai-ext/shared-providers'
+import type { CreateProviderOptions } from '@xsai-ext/providers/utils'
 import type { LoadOptions, PipelineOptionsFrom, PipelineSelfOptionsFrom, ProgressInfo } from '@xsai-transformers/shared/types'
 import type { GenerateTextResponse } from '@xsai/generate-text'
 import type { ChatOptions } from '@xsai/shared-chat'

--- a/packages/embed/package.json
+++ b/packages/embed/package.json
@@ -56,7 +56,7 @@
     "@huggingface/transformers": "^3.7.6",
     "@moeru/eventa": "^0.3.0",
     "@moeru/std": "^0.1.0-beta.13",
-    "@xsai-ext/shared-providers": "catalog:",
+    "@xsai-ext/providers": "catalog:",
     "@xsai-transformers/shared": "workspace:^",
     "@xsai/embed": "catalog:",
     "@xsai/shared": "catalog:",

--- a/packages/embed/src/index.ts
+++ b/packages/embed/src/index.ts
@@ -1,5 +1,5 @@
 import type { FeatureExtractionPipelineOptions } from '@huggingface/transformers'
-import type { EmbedProviderWithExtraOptions } from '@xsai-ext/shared-providers'
+import type { EmbedProviderWithExtraOptions } from '@xsai-ext/providers/utils'
 import type { LoadOptionProgressCallback, LoadOptions } from '@xsai-transformers/shared/types'
 import type { EmbedResponse } from '@xsai/embed'
 import type { CommonRequestOptions } from '@xsai/shared'

--- a/packages/embed/src/types/index.ts
+++ b/packages/embed/src/types/index.ts
@@ -1,5 +1,5 @@
 import type { FeatureExtractionPipelineOptions } from '@huggingface/transformers'
-import type { CreateProviderOptions } from '@xsai-ext/shared-providers'
+import type { CreateProviderOptions } from '@xsai-ext/providers/utils'
 import type { LoadOptions, ProgressInfo } from '@xsai-transformers/shared/types'
 
 export enum MessageStatus {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -53,7 +53,7 @@
     "@huggingface/transformers": "^3.7.6",
     "@moeru/eventa": "^0.3.0",
     "@moeru/std": "^0.1.0-beta.13",
-    "@xsai-ext/shared-providers": "catalog:",
+    "@xsai-ext/providers": "catalog:",
     "@xsai/shared": "catalog:",
     "onnxruntime-common": "^1.23.2"
   }

--- a/packages/speech/package.json
+++ b/packages/speech/package.json
@@ -54,7 +54,7 @@
   },
   "dependencies": {
     "@huggingface/transformers": "^3.7.6",
-    "@xsai-ext/shared-providers": "catalog:",
+    "@xsai-ext/providers": "catalog:",
     "@xsai-transformers/shared": "workspace:^",
     "@xsai/embed": "catalog:",
     "@xsai/shared": "catalog:"

--- a/packages/transcription/package.json
+++ b/packages/transcription/package.json
@@ -56,7 +56,7 @@
     "@huggingface/transformers": "^3.7.6",
     "@moeru/eventa": "^0.3.0",
     "@moeru/std": "^0.1.0-beta.13",
-    "@xsai-ext/shared-providers": "catalog:",
+    "@xsai-ext/providers": "catalog:",
     "@xsai-transformers/shared": "workspace:^",
     "@xsai/embed": "catalog:",
     "@xsai/generate-transcription": "catalog:",

--- a/packages/transcription/src/index.ts
+++ b/packages/transcription/src/index.ts
@@ -1,5 +1,5 @@
 import type { pipeline } from '@huggingface/transformers'
-import type { TranscriptionProviderWithExtraOptions } from '@xsai-ext/shared-providers'
+import type { TranscriptionProviderWithExtraOptions } from '@xsai-ext/providers/utils'
 import type { LoadOptionProgressCallback, LoadOptions, PipelineOptionsFrom } from '@xsai-transformers/shared/types'
 import type { GenerateTranscriptionResult } from '@xsai/generate-transcription'
 import type { CommonRequestOptions } from '@xsai/shared'

--- a/packages/transcription/src/types/index.ts
+++ b/packages/transcription/src/types/index.ts
@@ -1,5 +1,5 @@
 import type { pipeline } from '@huggingface/transformers'
-import type { CreateProviderOptions } from '@xsai-ext/shared-providers'
+import type { CreateProviderOptions } from '@xsai-ext/providers/utils'
 import type { LoadOptions, PipelineOptionsFrom, ProgressInfo } from '@xsai-transformers/shared/types'
 
 export enum MessageStatus {

--- a/packages/utils-vad/package.json
+++ b/packages/utils-vad/package.json
@@ -54,7 +54,7 @@
   },
   "dependencies": {
     "@huggingface/transformers": "^3.7.6",
-    "@xsai-ext/shared-providers": "catalog:",
+    "@xsai-ext/providers": "catalog:",
     "@xsai-transformers/shared": "workspace:^",
     "@xsai/embed": "catalog:",
     "@xsai/generate-transcription": "catalog:",

--- a/playground/package.json
+++ b/playground/package.json
@@ -43,7 +43,7 @@
     "@vitejs/plugin-vue": "^6.0.1",
     "@vueuse/core": "^14.0.0",
     "@webgpu/types": "^0.1.66",
-    "@xsai-ext/shared-providers": "catalog:",
+    "@xsai-ext/providers": "catalog:",
     "@xsai-transformers/shared": "workspace:^",
     "@xsai/embed": "catalog:",
     "@xsai/shared": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,9 +6,9 @@ settings:
 
 catalogs:
   default:
-    '@xsai-ext/shared-providers':
-      specifier: ^0.4.0-beta.9
-      version: 0.4.0-beta.9
+    '@xsai-ext/providers':
+      specifier: ^0.4.4
+      version: 0.4.4
     '@xsai/embed':
       specifier: ^0.4.0-beta.9
       version: 0.4.0-beta.9
@@ -126,9 +126,9 @@ importers:
 
   packages-top/xsai-transformers:
     dependencies:
-      '@xsai-ext/shared-providers':
+      '@xsai-ext/providers':
         specifier: 'catalog:'
-        version: 0.4.0-beta.9
+        version: 0.4.4
       '@xsai-transformers/chat':
         specifier: workspace:^
         version: link:../../packages/chat
@@ -156,9 +156,9 @@ importers:
       '@moeru/std':
         specifier: ^0.1.0-beta.13
         version: 0.1.0-beta.13
-      '@xsai-ext/shared-providers':
+      '@xsai-ext/providers':
         specifier: 'catalog:'
-        version: 0.4.0-beta.9
+        version: 0.4.4
       '@xsai-transformers/shared':
         specifier: workspace:^
         version: link:../shared
@@ -198,9 +198,9 @@ importers:
       '@moeru/std':
         specifier: ^0.1.0-beta.13
         version: 0.1.0-beta.13
-      '@xsai-ext/shared-providers':
+      '@xsai-ext/providers':
         specifier: 'catalog:'
-        version: 0.4.0-beta.9
+        version: 0.4.4
       '@xsai-transformers/shared':
         specifier: workspace:^
         version: link:../shared
@@ -228,9 +228,9 @@ importers:
       '@moeru/std':
         specifier: ^0.1.0-beta.13
         version: 0.1.0-beta.13
-      '@xsai-ext/shared-providers':
+      '@xsai-ext/providers':
         specifier: 'catalog:'
-        version: 0.4.0-beta.9
+        version: 0.4.4
       '@xsai/shared':
         specifier: 'catalog:'
         version: 0.4.0-beta.9
@@ -243,9 +243,9 @@ importers:
       '@huggingface/transformers':
         specifier: ^3.7.6
         version: 3.7.6
-      '@xsai-ext/shared-providers':
+      '@xsai-ext/providers':
         specifier: 'catalog:'
-        version: 0.4.0-beta.9
+        version: 0.4.4
       '@xsai-transformers/shared':
         specifier: workspace:^
         version: link:../shared
@@ -270,9 +270,9 @@ importers:
       '@moeru/std':
         specifier: ^0.1.0-beta.13
         version: 0.1.0-beta.13
-      '@xsai-ext/shared-providers':
+      '@xsai-ext/providers':
         specifier: 'catalog:'
-        version: 0.4.0-beta.9
+        version: 0.4.4
       '@xsai-transformers/shared':
         specifier: workspace:^
         version: link:../shared
@@ -297,9 +297,9 @@ importers:
       '@huggingface/transformers':
         specifier: ^3.7.6
         version: 3.7.6
-      '@xsai-ext/shared-providers':
+      '@xsai-ext/providers':
         specifier: 'catalog:'
-        version: 0.4.0-beta.9
+        version: 0.4.4
       '@xsai-transformers/shared':
         specifier: workspace:^
         version: link:../shared
@@ -379,9 +379,9 @@ importers:
       '@webgpu/types':
         specifier: ^0.1.66
         version: 0.1.66
-      '@xsai-ext/shared-providers':
+      '@xsai-ext/providers':
         specifier: 'catalog:'
-        version: 0.4.0-beta.9
+        version: 0.4.4
       '@xsai-transformers/shared':
         specifier: workspace:^
         version: link:../packages/shared
@@ -1603,8 +1603,8 @@ packages:
   '@webgpu/types@0.1.66':
     resolution: {integrity: sha512-YA2hLrwLpDsRueNDXIMqN9NTzD6bCDkuXbOSe0heS+f8YE8usA6Gbv1prj81pzVHrbaAma7zObnIC+I6/sXJgA==}
 
-  '@xsai-ext/shared-providers@0.4.0-beta.9':
-    resolution: {integrity: sha512-HCDZV9LFHpgoMiqGfyMIwDq6UOhC6B8fj1Skz1q6X8gMyUQhLbbY9cOf1ieWn4FFW2SXJvGKEsyIlL1CAdPigA==}
+  '@xsai-ext/providers@0.4.4':
+    resolution: {integrity: sha512-PVk3IFOPzPyvss9zY6IO6pJ890F5B6LWGWuhU6DzofWMTnqcUzm0hR2Ml/Qo8kZa3Qy/DZkUT0O1T+5g/fZkWw==}
 
   '@xsai/embed@0.4.0-beta.9':
     resolution: {integrity: sha512-Jgdif7M4xRVIAixd1XGbU6Ocaxm+DVDPrJG0ov79na973V3tqXbV49BlYqvmRaWoIrtMCCzfTxrJD342IKqEFA==}
@@ -1629,6 +1629,9 @@ packages:
 
   '@xsai/shared@0.4.0-beta.9':
     resolution: {integrity: sha512-AH9d7MkqBAqWCDTY6FVjenaMUBnOVdfG3tLQ8ORo0KsX70moMeu6CLzyt1z7tmsrcis3jHgYmw+StuK0VFtytg==}
+
+  '@xsai/shared@0.4.4':
+    resolution: {integrity: sha512-ZrOeRJ0fqV8YRDwyQbYJx1N8Fe2UTl2psjV7ucYJ+gMr3oWzrmNfTX9zrpV9zwzBMUe6VvqhK/iJzz8p4jYlsw==}
 
   '@xsai/stream-object@0.4.0-beta.9':
     resolution: {integrity: sha512-5pFkMtSECeKmzupHFwTWTBfdL+ei4uisef/ZVV+qx3FpZu1fBylMDVrf8yE5v8Nk9owUDS01uAk2n4NJIq58yQ==}
@@ -5307,9 +5310,9 @@ snapshots:
 
   '@webgpu/types@0.1.66': {}
 
-  '@xsai-ext/shared-providers@0.4.0-beta.9':
+  '@xsai-ext/providers@0.4.4':
     dependencies:
-      '@xsai/shared': 0.4.0-beta.9
+      '@xsai/shared': 0.4.4
 
   '@xsai/embed@0.4.0-beta.9':
     dependencies:
@@ -5350,6 +5353,8 @@ snapshots:
       '@xsai/shared': 0.4.0-beta.9
 
   '@xsai/shared@0.4.0-beta.9': {}
+
+  '@xsai/shared@0.4.4': {}
 
   '@xsai/stream-object@0.4.0-beta.9(zod-to-json-schema@3.24.5(zod@3.24.4))(zod@3.24.4)':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,8 +5,6 @@ packages:
 
 catalog:
   '@xsai-ext/providers': ^0.4.4
-  '@xsai-ext/providers-cloud': ^0.4.0-beta.9
-  '@xsai-ext/providers-local': ^0.4.0-beta.9
   '@xsai/embed': ^0.4.0-beta.9
   '@xsai/generate-object': ^0.4.0-beta.9
   '@xsai/generate-speech': ^0.4.0-beta.9

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,9 +4,9 @@ packages:
   - playground
 
 catalog:
+  '@xsai-ext/providers': ^0.4.4
   '@xsai-ext/providers-cloud': ^0.4.0-beta.9
   '@xsai-ext/providers-local': ^0.4.0-beta.9
-  '@xsai-ext/shared-providers': ^0.4.0-beta.9
   '@xsai/embed': ^0.4.0-beta.9
   '@xsai/generate-object': ^0.4.0-beta.9
   '@xsai/generate-speech': ^0.4.0-beta.9


### PR DESCRIPTION
Replace deprecated [@xsai-ext/shared-providers](https://www.npmjs.com/package/@xsai-ext/shared-providers) with [@xsai-ext/providers](https://www.npmjs.com/package/@xsai-ext/providers)
remove [@xsai-ext/providers-cloud](https://www.npmjs.com/package/@xsai-ext/providers-cloud) [@xsai-ext/providers-local](https://www.npmjs.com/package/@xsai-ext/providers-local) from pnpm-workspace.yaml because they are deprecated and not dependencies of any workspaces